### PR TITLE
Amended log handler to include stack trace

### DIFF
--- a/src/TeamsLogHandler.php
+++ b/src/TeamsLogHandler.php
@@ -43,7 +43,8 @@ class TeamsLogHandler extends AbstractProcessingHandler
     protected function getMessage(array $record)
     {
         return new TeamsMessage([
-            'text' => $record['level_name'] . ': ' . $record['message'],
+            'title' => $record['level_name'] . ': ' . $record['message'],
+            'text' => $record['formatted'],
             'themeColor' => self::$levelColors[$record['level']] ?? self::$levelColors[$this->level],
         ]);
     }


### PR DESCRIPTION
As it is, this log handler doesn't provide much in the way of contextual data. As a result, for my own use case I find that it's not very useful compared to the Slack handler since I have to dig into the log anyway.

This pull request moves the existing text to the title and inserts the context data into the main body.