### PR TITLE
Add “ReturnTypeWillChange” attribute for PHP 8.1

### DIFF
--- a/src/TeamsMessage.php
+++ b/src/TeamsMessage.php
@@ -46,6 +46,7 @@ class TeamsMessage implements ArrayAccess, JsonSerializable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;
@@ -63,6 +64,7 @@ class TeamsMessage implements ArrayAccess, JsonSerializable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -81,6 +83,7 @@ class TeamsMessage implements ArrayAccess, JsonSerializable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);


### PR DESCRIPTION
Make free way for @[togishima](https://github.com/togishima)'s Pull request #9 

This way, package version 1.2 can be preserved and can run on both PHP 7 and 8 – before a new “PHP 8 only” major release introduces the required return types.

